### PR TITLE
Fixed cppcheck unusedFunction option

### DIFF
--- a/Findcppcheck.cmake
+++ b/Findcppcheck.cmake
@@ -107,7 +107,7 @@ if(CPPCHECK_EXECUTABLE)
 	if("${CPPCHECK_STYLE_ARG}" STREQUAL "--enable=style")
 
 		_cppcheck_set_arg_var(CPPCHECK_UNUSEDFUNC_ARG
-			"--enable=unusedFunctions")
+			"--enable=unusedFunction")
 		_cppcheck_set_arg_var(CPPCHECK_INFORMATION_ARG "--enable=information")
 		_cppcheck_set_arg_var(CPPCHECK_MISSINGINCLUDE_ARG
 			"--enable=missingInclude")


### PR DESCRIPTION
According to the cppcheck manual (http://cppcheck.sourceforge.net/manual.pdf), the correct name of the check is 'unusedFunction' (singular) instead of 'unusedFunctions'.
