### PR TITLE
Support VS2012 and VS2013 SDKs

### DIFF
--- a/FindWindowsSDK.cmake
+++ b/FindWindowsSDK.cmake
@@ -69,10 +69,11 @@ if(MSVC_VERSION GREATER 1310) # Newer than VS .NET/VS Toolkit 2003
 		else()
 			set(_winsdk_vistaonly
 				v8.0
-				v8.0A)
+				v8.0A
+				v8.1A)
 		endif()
 	endif()
-	foreach(_winsdkver v7.1 v7.0A v6.1 v6.0A v6.0)
+	foreach(_winsdkver ${_winsdk_vistaonly} v7.1A v7.1 v7.0A v6.1 v6.0A v6.0)
 		get_filename_component(_sdkdir
 			"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\${_winsdkver};InstallationFolder]"
 			ABSOLUTE)


### PR DESCRIPTION
FindWindowsSDK.cmake was not updated to support the most recent versions of the SDK. On top of that, "winsdk_vistaonly" was being set but never used, and therefore results it would have picked up were excluded. I've patched it to locate v7.1A, v8.0, v8.0A and v8.1A now.