### PR TITLE
Use .git/packed-refs if ref is not found.

### DIFF
--- a/GetGitRevisionDescription.cmake.in
+++ b/GetGitRevisionDescription.cmake.in
@@ -1,4 +1,4 @@
-# 
+#
 # Internal file for GetGitRevisionDescription.cmake
 #
 # Requires CMake 2.6 or newer (uses the 'function' command)
@@ -23,9 +23,12 @@ if(HEAD_CONTENTS MATCHES "ref")
 	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
 	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
 		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
-	elseif(EXISTS "@GIT_DIR@/logs/${HEAD_REF}")
-		configure_file("@GIT_DIR@/logs/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
-		set(HEAD_HASH "${HEAD_REF}")
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
 	endif()
 else()
 	# detached HEAD


### PR DESCRIPTION
After `git gc` refs may be deleted. The ref can be found in the
`.git/packed-refs` file. This PR adds this functionality.

This should fix issue #33.