### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR consistently

### DIFF
--- a/GetGitRevisionDescription.cmake
+++ b/GetGitRevisionDescription.cmake
@@ -110,7 +110,7 @@ function(git_describe _var)
 		${hash}
 		${ARGN}
 		WORKING_DIRECTORY
-		"${CMAKE_SOURCE_DIR}"
+		"${CMAKE_CURRENT_SOURCE_DIR}"
 		RESULT_VARIABLE
 		res
 		OUTPUT_VARIABLE


### PR DESCRIPTION
get_git_head_revision uses CMAKE_CURRENT_SOURCE_DIR as starting point, so should git when invoking it