### PR TITLE
Fix wrong check in BoostTestTargets.cmake

### DIFF
--- a/BoostTestTargets.cmake
+++ b/BoostTestTargets.cmake
@@ -159,7 +159,7 @@ function(add_boost_test _name)
 		endforeach()
 
 		if(NOT _boostTestTargetsNagged${_name} STREQUAL "${includeType}")
-			if("includeType" STREQUAL "CONFIGURED")
+			if("${includeType}" STREQUAL "CONFIGURED")
 				message(STATUS
 					"Test '${_name}' uses the CMake-configurable form of the boost test framework - congrats! (Including File: ${includeFileLoc})")
 			elseif("${includeType}" STREQUAL "INCLUDED")


### PR DESCRIPTION
Fix a missing variable identifier so that the "Didn't detect the CMake-configurable boost test include." warning will not appear if the include file is, indeed, added correctly.