### PR TITLE
Add generator expression support to CreateLauncher

### DIFF
--- a/launcher-templates/perconfig.vcproj.user.in
+++ b/launcher-templates/perconfig.vcproj.user.in
@@ -2,7 +2,7 @@
 			Name="@USERFILE_CONFIGNAME@|@USERFILE_PLATFORM@"
 			>
 			<DebugSettings
-				Command="${USERFILE_@USERFILE_CONFIGNAME@_COMMAND}"
+				Command="@USERFILE_COMMAND@"
 				WorkingDirectory="@USERFILE_WORKING_DIRECTORY@"
 				CommandArguments="@USERFILE_COMMAND_ARGUMENTS@"
 				Attach="false"

--- a/launcher-templates/perconfig.vcxproj.user.in
+++ b/launcher-templates/perconfig.vcxproj.user.in
@@ -1,7 +1,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='@USERFILE_CONFIGNAME@|@USERFILE_PLATFORM@'">
     <LocalDebuggerEnvironment>@USERFILE_ENVIRONMENT@</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommand>${USERFILE_@USERFILE_CONFIGNAME@_COMMAND}</LocalDebuggerCommand>
+    <LocalDebuggerCommand>@USERFILE_COMMAND@</LocalDebuggerCommand>
     <LocalDebuggerCommandArguments>@USERFILE_COMMAND_ARGUMENTS@</LocalDebuggerCommandArguments>
     <LocalDebuggerWorkingDirectory>@USERFILE_WORKING_DIRECTORY@</LocalDebuggerWorkingDirectory>
   </PropertyGroup>


### PR DESCRIPTION
This uses generator expression to get rid of the cmake warnings with using the LOCATION property of the target. Also since generator expressions are being decoded in the file(GENERATE ...) call you can feed CreateLauncher generator expressions.