### PR TITLE
Direct hint on CMake command line options

### DIFF
--- a/cmake-4.0.0-modules/RequireOutOfSourceBuild.cmake
+++ b/cmake-4.0.0-modules/RequireOutOfSourceBuild.cmake
@@ -39,6 +39,6 @@ foreach(_var ${_test})
 	if("${_bin}" STREQUAL "${_chopped}")
 		get_filename_component(_parent "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
 		message(FATAL_ERROR
-			"You must set a binary directory that is different from your source directory.  You might consider ${CMAKE_SOURCE_DIR}/build or ${_parent}/build-${CMAKE_PROJECT_NAME}")
+			"You must set a binary directory that is different from your source directory.  You might consider cmake options: -B${CMAKE_SOURCE_DIR}/build or -B${_parent}/build-${CMAKE_PROJECT_NAME}")
 	endif()
 endforeach()


### PR DESCRIPTION
Error in RequireOutOfSourceBuild.cmake cannot be solved without knowledge of all CMake options. Patch set direct hint on option "-B".

$ cmake .
...
-- Configuring WiiUse version 0.15.4
CMake Error at lib/wiiuse/cmake/cmake-4.0.0-modules/RequireOutOfSourceBuild.cmake:41 (message):
  You must set a binary directory that is different from your source
  directory.  You might consider
  /home/nwtour/stk/stk-code/build or /home/nwtour/stk/build-SuperTuxKart
Call Stack (most recent call first):
  lib/wiiuse/cmake/cmake-4.0.0-modules/autoinclude.cmake:13 (include)
  lib/wiiuse/cmake/UseBackportedModules.cmake:92 (include)
  lib/wiiuse/CMakeLists.txt:38 (include)