### PR TITLE
Allow `git describe` to function without tags

### DIFF
--- a/GetGitRevisionDescription.cmake
+++ b/GetGitRevisionDescription.cmake
@@ -116,7 +116,7 @@ function(git_describe _var)
 
 	execute_process(COMMAND
 		"${GIT_EXECUTABLE}"
-		describe
+		describe --tags --always
 		${hash}
 		${ARGN}
 		WORKING_DIRECTORY


### PR DESCRIPTION
Closes #12

Note that --always must be paired with --tags to get the expected output
in the most common use case when there are tags. Without it only the
short hash is ever returned. Combined with --tags the output is the same
as previous when tags are present but will fall back to identifying the
commit by its hash if no tags are found.