### PR TITLE
Enabled correct handling of worktrees

### DIFF
--- a/GetGitRevisionDescription.cmake
+++ b/GetGitRevisionDescription.cmake
@@ -45,41 +45,89 @@ set(__get_git_revision_description YES)
 # to find the path to this module rather than the path to a calling list file
 get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
-function(get_git_head_revision _refspecvar _hashvar)
-	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
-	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
-		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
-		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
-		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+# Function find_closest_git_dir finds the next closest .git directory 
+# that is part of any directory in the path defined by _start_dir.
+# The result is returned in the parent scope variable whose name is passed 
+# as variable _git_dir_var. If no .git directory can be found, the 
+# function returns an empty string via _git_dir_var.
+#
+# Example: Given a path C:/bla/foo/bar and assuming C:/bla/.git exists and 
+# neither foo nor bar contain a file/directory .git. This wil return 
+# C:/bla/.git
+#
+function(find_closest_git_dir _start_dir _git_dir_var)
+	set(cur_dir "${_start_dir}")
+	set(git_dir "${_start_dir}/.git")
+	while(NOT EXISTS "${git_dir}")	# .git dir not found, search parent directories
+		set(git_previous_parent "${cur_dir}")
+		get_filename_component(cur_dir ${cur_dir} DIRECTORY)
+		if(cur_dir STREQUAL git_previous_parent)
 			# We have reached the root directory, we are not in git
-			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
-			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			set(${_git_dir_var} "" PARENT_SCOPE)
 			return()
 		endif()
-		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+		set(git_dir "${cur_dir}/.git")
 	endwhile()
-	# check if this is a submodule
-	if(NOT IS_DIRECTORY ${GIT_DIR})
-		file(READ ${GIT_DIR} submodule)
-		string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
-		get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
-		get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+	set(${_git_dir_var} "${git_dir}" PARENT_SCOPE)
+endfunction()
+
+function(get_git_head_revision _refspecvar _hashvar)
+	find_closest_git_dir("${CMAKE_CURRENT_SOURCE_DIR}" GIT_DIR)
+	if("${GIT_DIR}" STREQUAL "")
+	   set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+		set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+		return()
 	endif()
-	if(NOT IS_DIRECTORY "${GIT_DIR}")
-		file(READ ${GIT_DIR} worktree)
- 		string(REGEX REPLACE "gitdir: (.*)worktrees(.*)\n$" "\\1" GIT_DIR ${worktree})
- 	endif()
+	
+	# Check if the current source dir is a git submodule or a worktree.
+	# In both cases .git is a file instead of a directory.
+	#
+	if(NOT IS_DIRECTORY ${GIT_DIR})
+		# The following git command will return a non empty string that 
+		# points to the super project working tree if the current 
+		# source dir is inside a git submodule.
+		# Otherwise the command will return an empty string.
+		#
+		execute_process(COMMAND
+			"${GIT_EXECUTABLE}"
+			rev-parse --show-superproject-working-tree
+			WORKING_DIRECTORY
+			"${CMAKE_CURRENT_SOURCE_DIR}"
+			OUTPUT_VARIABLE
+			out
+			ERROR_QUIET
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+		if(NOT "${out}" STREQUAL "")
+			# If out is empty, GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a submodule
+			file(READ ${GIT_DIR} submodule)
+			string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+			get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+			get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+			set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+		else()
+			# GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a worktree
+			file(READ ${GIT_DIR} worktree_ref)
+			# The .git directory contains a path to the worktree information directory 
+			# inside the parent git repo of the worktree.
+			#
+			string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" git_worktree_dir ${worktree_ref})
+			find_closest_git_dir("${git_worktree_dir}" GIT_DIR)
+			set(HEAD_SOURCE_FILE "${git_worktree_dir}/HEAD")
+		endif()
+	else()
+		set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+	endif()
 	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
 	if(NOT EXISTS "${GIT_DATA}")
 		file(MAKE_DIRECTORY "${GIT_DATA}")
 	endif()
 
-	if(NOT EXISTS "${GIT_DIR}/HEAD")
+	if(NOT EXISTS "${HEAD_SOURCE_FILE}")
 		return()
 	endif()
 	set(HEAD_FILE "${GIT_DATA}/HEAD")
-	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+	configure_file("${HEAD_SOURCE_FILE}" "${HEAD_FILE}" COPYONLY)
 
 	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
 		"${GIT_DATA}/grabRef.cmake"


### PR DESCRIPTION
This change adds more robust handling of git worktrees.

An attempt to handle worktrees had already been submitted as https://github.com/rpavlik/cmake-modules/commit/e22a3e681438411c3fa86f9958428caf91fe62fd but does not work under all circumstances.

Here's why the current worktree handling fails:

The part newly introduced by https://github.com/rpavlik/cmake-modules/commit/e22a3e681438411c3fa86f9958428caf91fe62fd
```
if(NOT IS_DIRECTORY "${GIT_DIR}")
   file(READ ${GIT_DIR} worktree)
   string(REGEX REPLACE "gitdir: (.*)worktrees(.*)\n$" "\\1" GIT_DIR ${worktree})
endif()
```
assumes that `GIT_DIR` is an existing path, either a directory or a file. But in my case the variable `GIT_DIR` evaluates to something like e.g. `C:/some_path/C:/some_path/.git/worktrees/some_repo` which is not a valid path. Nonetheless, the expression `NOT IS_DIRECTORY "${GIT_DIR}"` evaluates to true for anything that is not an exisiting file. CMake thus tries to read the broken GIT_DIR and fails.