### PR TITLE
Add git_committime to get the timestamp of the last commit.

### DIFF
--- a/GetGitRevisionDescription.cmake
+++ b/GetGitRevisionDescription.cmake
@@ -215,6 +215,49 @@ function(git_describe _var)
         PARENT_SCOPE)
 endfunction()
 
+function(git_committime _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    get_git_head_revision(refspec hash)
+    if(NOT GIT_FOUND)
+        set(${_var}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT hash)
+        set(${_var}
+            "HEAD-HASH-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    # TODO sanitize
+    #if((${ARGN}" MATCHES "&&") OR
+    #    (ARGN MATCHES "||") OR
+    #    (ARGN MATCHES "\\;"))
+    #    message("Please report the following error to the project!")
+    #    message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+    #endif()
+
+    #message(STATUS "Arguments to execute_process: ${ARGN}")
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" log --format=%cd --date=iso8601 -n1 ${hash} ${ARGN}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
+        set(out "${out}-${res}-NOTFOUND")
+    endif()
+
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE)
+endfunction()
+
 function(git_describe_working_tree _var)
     if(NOT GIT_FOUND)
         find_package(Git QUIET)

--- a/GetGitRevisionDescription.cmake
+++ b/GetGitRevisionDescription.cmake
@@ -12,6 +12,12 @@
 # Returns the results of git describe on the source tree, and adjusting
 # the output so that it tests false if an error occurs.
 #
+# git_committime(<var> [<additional arguments to git log> ...])
+#
+# Extracts the timestamp of the last commmit in ISO 8601 format.
+# By passing an extra "--date=format:.." the time formating can be tweaked.
+# See the manpage of git-log for details.
+#
 #  git_describe_working_tree(<var> [<additional arguments to git describe> ...])
 #
 # Returns the results of git describe on the working tree (--dirty option),


### PR DESCRIPTION
This is e.g useful as more human-friendly, and for reproducible builds a better
alternative than `__TIME__` and `__DATE__`

Kudos for this module!