### PR TITLE
Add new Windows SDK versions in FindWindowsSDK.cmake

### DIFF
--- a/FindWindowsSDK.cmake
+++ b/FindWindowsSDK.cmake
@@ -77,6 +77,7 @@ endmacro()
 # although version numbers listed on that page don't necessarily match the directory
 # used by the installer.
 set(_winsdk_win10vers
+	10.0.22000.0 # Win11 2110 "21H2"
 	10.0.20348.0 # Win10 2104 "21H1"
 	10.0.19041.0 # Win10 2004 "20H1"
 	10.0.18362.0 # Win10 1903 "19H1"

--- a/FindWindowsSDK.cmake
+++ b/FindWindowsSDK.cmake
@@ -77,6 +77,8 @@ endmacro()
 # although version numbers listed on that page don't necessarily match the directory
 # used by the installer.
 set(_winsdk_win10vers
+	10.0.20348.0 # Win10 2104 "21H1"
+	10.0.19041.0 # Win10 2004 "20H1"
 	10.0.18362.0 # Win10 1903 "19H1"
 	10.0.17763.0 # Win10 1809 "October 2018 Update"
 	10.0.17134.0 # Redstone 4 aka Win10 1803 "April 2018 Update"


### PR DESCRIPTION
New Windows SDK versions are added:
- 10.0.22000.0 - Win11 2110 "21H2"
- 10.0.20348.0 - Win10 2104 "21H1"
- 10.0.19041.0 - Win10 2004 "20H1"