### PR TITLE
[GetGitRevisionDescription] Fix submodule check

### DIFF
--- a/GetGitRevisionDescription.cmake
+++ b/GetGitRevisionDescription.cmake
@@ -124,7 +124,7 @@ function(get_git_head_revision _refspecvar _hashvar)
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             OUTPUT_VARIABLE out
             ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-        if(NOT "${out}" STREQUAL "")
+        if("${out}" STREQUAL "")
             # If out is empty, GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a submodule
             file(READ ${GIT_DIR} submodule)
             string(REGEX REPLACE "gitdir: (.*)$" "\\1" GIT_DIR_RELATIVE


### PR DESCRIPTION
Fix inverted logic when checking if we are in a Git submodule. If we are in a submodule, `out` will be empty (as the comment correctly states). Therefore, we need to enter this block of code if `out` *is* empty, rather than *not* empty.